### PR TITLE
Include "nativeStack" key for native exceptions, include unit-test

### DIFF
--- a/iphone/Classes/GeolocationModule.m
+++ b/iphone/Classes/GeolocationModule.m
@@ -582,6 +582,8 @@ extern NSString *const TI_APPLICATION_GUID;
 - (void)setAccuracy:(NSNumber *)value
 {
   ENSURE_UI_THREAD(setAccuracy, value);
+  ENSURE_TYPE(value, NSNumber);
+
   accuracy = [TiUtils doubleValue:value];
   // don't prematurely start it
   if (locationManager != nil) {

--- a/tests/Resources/ti.addontest.js
+++ b/tests/Resources/ti.addontest.js
@@ -22,7 +22,7 @@ describe('Error', function () {
 			ex.should.have.readOnlyProperty('message').which.is.a.String;
 			// has "stack" property
 			ex.should.have.readOnlyProperty('stack').which.is.a.String;
-            // does not have native stack trace
+			// does not have native stack trace
 			ex.should.not.have.property('nativeStack');
 		}
 	});
@@ -35,9 +35,9 @@ describe('Error', function () {
 			// has "message" property
 			ex.should.have.readOnlyProperty('message').which.is.a.String;
 			// has "stack" property
-            ex.should.have.readOnlyProperty('stack').which.is.a.String;
-            // has special "nativeStack" property for native stacktrace
-            // TODO: Should we make this an array instead? 
+			ex.should.have.readOnlyProperty('stack').which.is.a.String;
+			// has special "nativeStack" property for native stacktrace
+			// TODO: Should we make this an array instead? 
 			ex.should.have.property('nativeStack').which.is.a.String;
 		}
 	});

--- a/tests/Resources/ti.addontest.js
+++ b/tests/Resources/ti.addontest.js
@@ -1,0 +1,56 @@
+/*
+ * Appcelerator Titanium Mobile
+ * Copyright (c) 2011-Present by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+/* eslint-env mocha */
+/* global Ti */
+/* eslint no-unused-expressions: "off" */
+'use strict';
+var should = require('./utilities/assertions'); // eslint-disable-line no-unused-vars
+
+describe('Error', function () {
+	it.windowsMissing('JavaScript exceptions', function () {
+		var e = {};
+
+		try {
+			Ti.API.info(e.test.crash);
+			should.fail('Expected to throw JavaScript exception');
+		} catch (ex) {
+			// has "message" property
+			ex.should.have.readOnlyProperty('message').which.is.a.String;
+			// has "stack" property
+			ex.should.have.readOnlyProperty('stack').which.is.a.String;
+            // does not have native stack trace
+			ex.should.not.have.property('nativeStack');
+		}
+	});
+
+	it.windowsMissing('Native exceptions', function () {
+		try {
+			Ti.Geolocation.accuracy = null;
+			should.fail('Expected to throw native exception');
+		} catch (ex) {
+			// has "message" property
+			ex.should.have.readOnlyProperty('message').which.is.a.String;
+			// has "stack" property
+            ex.should.have.readOnlyProperty('stack').which.is.a.String;
+            // has special "nativeStack" property for native stacktrace
+            // TODO: Should we make this an array instead? 
+			ex.should.have.property('nativeStack').which.is.a.String;
+		}
+	});
+
+	it.windowsMissing('String (literal) exceptions', function () {
+		try {
+			throw ('this is my error string'); // eslint-disable-line no-throw-literal
+		} catch (ex) {
+			ex.should.be.a.String;
+			ex.should.equal('this is my error string');
+			ex.should.not.have.property('message');
+			ex.should.not.have.property('stack');
+			ex.should.not.have.property('nativeStack');
+		}
+	});
+});


### PR DESCRIPTION
As per discussion in https://github.com/appcelerator/titanium_mobile/pull/10022. We may want to change the unit-tests here as well, but need to adjust the message checks.